### PR TITLE
fix: warn on invalid headers rather than crash

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import typescript from "rollup-plugin-typescript2";
 
 export default {
+  external: ["forwarded-parse", "pino"],
   input: "src/index.ts",
   output: [
     {

--- a/src/utils/userIP.ts
+++ b/src/utils/userIP.ts
@@ -43,9 +43,10 @@ export function processUserIP(req: Request): string | null {
         const firstIP = getFirstOrOnly(header);
         return parseIP(firstIP);
       } catch (e) {
-        throw new Error(
+        logger.warn(
           `Request received with invalid content in "${HEADER_CLOUDFRONT_VIEWER}" header.`
         );
+        return null;
       }
     }
     case IPSources.Forwarded: {
@@ -56,9 +57,10 @@ export function processUserIP(req: Request): string | null {
         const firstEntry = forwardedParse(header)[0];
         return parseIP(firstEntry.for);
       } catch (e) {
-        throw new Error(
+        logger.warn(
           `Request received with invalid content in "${HEADER_FORWARDED}" header.`
         );
+        return null;
       }
     }
     case IPSources.XForwardedFor: {


### PR DESCRIPTION
Based on conversation: https://gds.slack.com/archives/C06GXH2TNSW/p1714491220775779?thread_ts=1714126104.617619&cid=C06GXH2TNSW