### PR TITLE
chore: export PersonalDataHeaders interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const HEADERS = {
   OUTBOUND_FORWARDED_HEADER: 'x-forwarded-for'
 } as const
 
-interface PersonalDataHeaders {
+export interface PersonalDataHeaders {
   [HEADERS.HEADER_TXMA]?: string | string [],
   [HEADERS.OUTBOUND_FORWARDED_HEADER]?: string | string []
 }


### PR DESCRIPTION
Exporting this so it appears in the index.d.ts in the npm package. This can then be used by consumers.