### PR TITLE
fix(DCMAW-9395): make header fetching case-insensitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/frontend-passthrough-headers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/frontend-passthrough-headers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Headers for the frontend package to passthrough to downstream services",
   "type": "module",
   "esnext": "src/index.ts",

--- a/src/__test__/specs/index.spec.ts
+++ b/src/__test__/specs/index.spec.ts
@@ -18,9 +18,19 @@ describe("createPersonalDataHeaders", () => {
   });
 
   describe("handle txma-audit-encoded header", () => {
-    it("should return an object with the txma-audit-encoded header if there is one present", () => {
+    it("should return an object with the txma-audit-encoded header if there is one present - lower case", () => {
       const headers = createPersonalDataHeaders("https://account.gov.uk", {
         headers: { ["txma-audit-encoded"]: "dummy-txma-header" },
+      } as unknown as Request);
+
+      expect(headers).toEqual({
+        ["txma-audit-encoded"]: "dummy-txma-header",
+      });
+    });
+
+    it("should return an object with the txma-audit-encoded header if there is one present - upper case", () => {
+      const headers = createPersonalDataHeaders("https://account.gov.uk", {
+        headers: { ["Txma-Audit-Encoded"]: "dummy-txma-header" },
       } as unknown as Request);
 
       expect(headers).toEqual({
@@ -39,7 +49,7 @@ describe("createPersonalDataHeaders", () => {
 
   describe("handle x-forwarded-for header", () => {
     describe("handle 'cloudfront-viewer-address' input", () => {
-      it("should prioritise cloudfront and extract an IPv4 from the 'cloudfront-viewer-address' header", () => {
+      it("should prioritise cloudfront and extract an IPv4 from the 'cloudfront-viewer-address' header - lower case", () => {
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
             "cloudfront-viewer-address": MOCK_CLOUDFRONT_VIEWER_IPV4,
@@ -54,7 +64,22 @@ describe("createPersonalDataHeaders", () => {
         });
       });
 
-      it("should prioritise cloudfront and extract an IPv6 from the 'cloudfront-viewer-address' header", () => {
+      it("should prioritise cloudfront and extract an IPv4 from the 'cloudfront-viewer-address' header - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "Cloudfront-Viewer-Address": MOCK_CLOUDFRONT_VIEWER_IPV4,
+            Forwarded: MOCK_FORWARDED_IPV4,
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+
+        expect(headers).toEqual({
+          "x-forwarded-for": "198.51.100.10",
+        });
+      });
+
+      it("should prioritise cloudfront and extract an IPv6 from the 'cloudfront-viewer-address' header - lower case", () => {
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
             "cloudfront-viewer-address": MOCK_CLOUDFRONT_VIEWER_IPV6,
@@ -69,7 +94,22 @@ describe("createPersonalDataHeaders", () => {
         });
       });
 
-      it("should log a warning and not return the header on an invalid 'cloudfront-viewer-address' header", () => {
+      it("should prioritise cloudfront and extract an IPv6 from the 'cloudfront-viewer-address' header - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "Cloudfront-Viewer-Address": MOCK_CLOUDFRONT_VIEWER_IPV6,
+            Forwarded: MOCK_FORWARDED_IPV4,
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+
+        expect(headers).toEqual({
+          "x-forwarded-for": "2001:db8:cafe::17",
+        });
+      });
+
+      it("should log a warning and not return the header on an invalid 'cloudfront-viewer-address' header - lower case", () => {
         const spyLogger = jest.spyOn(logger, "warn");
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
@@ -80,14 +120,30 @@ describe("createPersonalDataHeaders", () => {
           ip: "198.51.100.13",
         } as unknown as Request);
         expect(spyLogger).toHaveBeenCalledWith(
-          'Request received with invalid content in "cloudfront-viewer-address" header.',
+          'Request received with invalid content in "cloudfront-viewer-address" header.'
+        );
+        expect(headers).toEqual({});
+      });
+
+      it("should log a warning and not return the header on an invalid 'cloudfront-viewer-address' header - upper case", () => {
+        const spyLogger = jest.spyOn(logger, "warn");
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "Cloudfront-Viewer-Address": "fgfgn4t428fcxcz'][]/.",
+            Forwarded: MOCK_FORWARDED_IPV4,
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+        expect(spyLogger).toHaveBeenCalledWith(
+          'Request received with invalid content in "cloudfront-viewer-address" header.'
         );
         expect(headers).toEqual({});
       });
     });
 
     describe("handle 'forwarded' input", () => {
-      it("should fall back to forwarded and extract an IPv4 from the 'forwarded' header", () => {
+      it("should fall back to forwarded and extract an IPv4 from the 'forwarded' header - lower case", () => {
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
             forwarded: MOCK_FORWARDED_IPV4,
@@ -101,7 +157,21 @@ describe("createPersonalDataHeaders", () => {
         });
       });
 
-      it("should fall back to forwarded and extract an IPv6 from the 'forwarded' header", () => {
+      it("should fall back to forwarded and extract an IPv4 from the 'forwarded' header - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            Forwarded: MOCK_FORWARDED_IPV4,
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+
+        expect(headers).toEqual({
+          "x-forwarded-for": "198.51.100.11",
+        });
+      });
+
+      it("should fall back to forwarded and extract an IPv6 from the 'forwarded' header - lower case", () => {
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
             forwarded: MOCK_FORWARDED_IPV6,
@@ -115,7 +185,21 @@ describe("createPersonalDataHeaders", () => {
         });
       });
 
-      it("should log a warning and not return a header on an invalid 'forwarded' header", () => {
+      it("should fall back to forwarded and extract an IPv6 from the 'forwarded' header - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            Forwarded: MOCK_FORWARDED_IPV6,
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+
+        expect(headers).toEqual({
+          "x-forwarded-for": "2003:db8:cafe::17",
+        });
+      });
+
+      it("should log a warning and not return a header on an invalid 'forwarded' header - lower case", () => {
         const spyLogger = jest.spyOn(logger, "warn");
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
@@ -125,14 +209,29 @@ describe("createPersonalDataHeaders", () => {
           ip: "198.51.100.13",
         } as unknown as Request);
         expect(spyLogger).toHaveBeenCalledWith(
-          'Request received with invalid content in "forwarded" header.',
+          'Request received with invalid content in "forwarded" header.'
+        );
+        expect(headers).toEqual({});
+      });
+
+      it("should log a warning and not return a header on an invalid 'forwarded' header - upper case", () => {
+        const spyLogger = jest.spyOn(logger, "warn");
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            Forwarded: "fgfgn4t428fcxcz'][]/.",
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+        expect(spyLogger).toHaveBeenCalledWith(
+          'Request received with invalid content in "forwarded" header.'
         );
         expect(headers).toEqual({});
       });
     });
 
     describe("handle 'x-forwarded-for' input", () => {
-      it("should fall back to x-forwarded-for and extract an IPv4 from the 'x-forwarded-for' header", () => {
+      it("should fall back to x-forwarded-for and extract an IPv4 from the 'x-forwarded-for' header - lower case", () => {
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
             "x-forwarded-for": MOCK_X_FORWARDED_FOR_IPV4,
@@ -145,7 +244,20 @@ describe("createPersonalDataHeaders", () => {
         });
       });
 
-      it("should fall back to x-forwarded-for and extract an IPv4 from ApiGatewayProxyEvent request", () => {
+      it("should fall back to x-forwarded-for and extract an IPv4 from the 'x-forwarded-for' header - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+
+        expect(headers).toEqual({
+          "x-forwarded-for": "198.51.100.13",
+        });
+      });
+
+      it("should fall back to x-forwarded-for and extract an IPv4 from ApiGatewayProxyEvent request - lower case", () => {
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
             "x-forwarded-for": MOCK_X_FORWARDED_FOR_IPV4,
@@ -162,7 +274,24 @@ describe("createPersonalDataHeaders", () => {
         });
       });
 
-      it("should fall back to x-forwarded-for and extract an IPv6 from the 'x-forwarded-for' header", () => {
+      it("should fall back to x-forwarded-for and extract an IPv4 from ApiGatewayProxyEvent request - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          requestContext: {
+            identity: {
+              sourceIp: "198.51.100.13",
+            },
+          },
+        } as unknown as APIGatewayProxyEvent);
+
+        expect(headers).toEqual({
+          "x-forwarded-for": "198.51.100.13",
+        });
+      });
+
+      it("should fall back to x-forwarded-for and extract an IPv6 from the 'x-forwarded-for' header - lower case", () => {
         const headers = createPersonalDataHeaders("https://account.gov.uk", {
           headers: {
             "x-forwarded-for": MOCK_X_FORWARDED_FOR_IPV6,
@@ -174,29 +303,57 @@ describe("createPersonalDataHeaders", () => {
           "x-forwarded-for": "2005:db8:cafe::17",
         });
       });
-    });
 
-    it("should fallback through headers which have empty content", () => {
-      const headers = createPersonalDataHeaders("https://account.gov.uk", {
-        headers: {
-          "cloudfront-viewer-address": "",
-          forwarded: MOCK_FORWARDED_IPV4,
-          "x-forwarded-for": MOCK_X_FORWARDED_FOR_IPV4,
-        },
-        ip: "198.51.100.13",
-      } as unknown as Request);
+      it("should fall back to x-forwarded-for and extract an IPv6 from the 'x-forwarded-for' header - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV6,
+          },
+          ip: "2005:db8:cafe::17",
+        } as unknown as Request);
 
-      expect(headers).toEqual({
-        "x-forwarded-for": "198.51.100.11",
+        expect(headers).toEqual({
+          "x-forwarded-for": "2005:db8:cafe::17",
+        });
       });
-    });
 
-    it("should return null if none of the headers are included", () => {
-      const headers = createPersonalDataHeaders("https://account.gov.uk", {
-        headers: {},
-      } as unknown as Request);
+      it("should fallback through headers which have empty content - lower case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "cloudfront-viewer-address": "",
+            forwarded: MOCK_FORWARDED_IPV4,
+            "x-forwarded-for": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
 
-      expect(headers).toEqual({});
+        expect(headers).toEqual({
+          "x-forwarded-for": "198.51.100.11",
+        });
+      });
+
+      it("should fallback through headers which have empty content - upper case", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {
+            "Cloudfront-Viewer-Address": "",
+            Forwarded: MOCK_FORWARDED_IPV4,
+            "X-Forwarded-For": MOCK_X_FORWARDED_FOR_IPV4,
+          },
+          ip: "198.51.100.13",
+        } as unknown as Request);
+
+        expect(headers).toEqual({
+          "x-forwarded-for": "198.51.100.11",
+        });
+      });
+
+      it("should return null if none of the headers are included", () => {
+        const headers = createPersonalDataHeaders("https://account.gov.uk", {
+          headers: {},
+        } as unknown as Request);
+
+        expect(headers).toEqual({});
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,16 @@ import { type Request } from "express";
 import { logger } from "./utils/logger";
 import { processUserIP } from "./utils/userIP";
 import { APIGatewayProxyEvent } from "aws-lambda";
+import { getHeader } from "./utils/getHeader";
 
 const HEADERS = {
   HEADER_TXMA: "txma-audit-encoded",
   OUTBOUND_FORWARDED_HEADER: "x-forwarded-for",
 } as const;
 
-interface PersonalDataHeaders {
-  [HEADERS.HEADER_TXMA]?: string | string[];
-  [HEADERS.OUTBOUND_FORWARDED_HEADER]?: string | string[];
+export interface PersonalDataHeaders {
+  [HEADERS.HEADER_TXMA]?: string;
+  [HEADERS.OUTBOUND_FORWARDED_HEADER]?: string;
 }
 
 /**
@@ -24,16 +25,17 @@ interface PersonalDataHeaders {
  */
 export function createPersonalDataHeaders(
   url: string,
-  req: Request | APIGatewayProxyEvent,
+  req: Request | APIGatewayProxyEvent
 ): PersonalDataHeaders {
   const domain = new URL(url).hostname;
   const personalDataHeaders: PersonalDataHeaders = {};
 
-  const txmaAuditEncodedHeader = req.headers[HEADERS.HEADER_TXMA];
+  const txmaAuditEncodedHeader = getHeader(req, HEADERS.HEADER_TXMA) as string;
+
   if (txmaAuditEncodedHeader) {
     personalDataHeaders[HEADERS.HEADER_TXMA] = txmaAuditEncodedHeader;
     logger.trace(
-      `Personal Data header "${HEADERS.HEADER_TXMA}" is being forwarded to domain "${domain}"`,
+      `Personal Data header "${HEADERS.HEADER_TXMA}" is being forwarded to domain "${domain}"`
     );
   }
 
@@ -41,7 +43,7 @@ export function createPersonalDataHeaders(
   if (userIP) {
     personalDataHeaders[HEADERS.OUTBOUND_FORWARDED_HEADER] = userIP;
     logger.trace(
-      `Personal Data header "${HEADERS.OUTBOUND_FORWARDED_HEADER}" is being forwarded to domain "${domain}"`,
+      `Personal Data header "${HEADERS.OUTBOUND_FORWARDED_HEADER}" is being forwarded to domain "${domain}"`
     );
   }
 

--- a/src/utils/getHeader.ts
+++ b/src/utils/getHeader.ts
@@ -1,0 +1,10 @@
+import { type Request } from "express";
+import { APIGatewayProxyEvent } from "aws-lambda";
+
+export function getHeader(req: Request | APIGatewayProxyEvent, header: string) {
+  const lowerCaseHeader = header.toLowerCase();
+  const matchingKey = Object.keys(req.headers).find(
+    (key) => key.toLowerCase() === lowerCaseHeader
+  );
+  return matchingKey ? req.headers[matchingKey] : undefined;
+}


### PR DESCRIPTION
This PR makes the fetching of headers case-insensitive to match the HTTP spec: https://www.rfc-editor.org/rfc/rfc9110.html#name-field-names